### PR TITLE
`download_datasets.py` threw `FileNotFoundError`

### DIFF
--- a/download_datasets.py
+++ b/download_datasets.py
@@ -2,7 +2,11 @@ import gdown
 import zipfile
 import subprocess
 import urllib.request
+import os
 
+# Make folder to save data in. 
+os.makedirs('./data', exist_ok=True)
+    
 # nerf
 print('Downloading blender dataset')
 gdown.download("https://drive.google.com/uc?id=18JxhpWD-4ZmuFKLzKlAw-w5PpzZxXOcG", './data/nerf_synthetic.zip')


### PR DESCRIPTION
The first call to download using `gdown` required the folder `./data` to exist otherwise a `FileNotFoundError` was thrown. I've just added an `os.makedirs()` that will create this folder. The `exist_ok=True` means that this should work even if the command is repeated (no error and won't overwrite existing folder).